### PR TITLE
Fixing typos so it compiles.

### DIFF
--- a/ArduinoSlackBot.cpp
+++ b/ArduinoSlackBot.cpp
@@ -1,5 +1,5 @@
 
-#include "espSlackBot.h"
+#include "ArduinoSlackBot.h"
 
 ArduinoSlackBot* ArduinoSlackBot::ptrBot = 0; 
 

--- a/ArduinoSlackBot.h
+++ b/ArduinoSlackBot.h
@@ -65,7 +65,7 @@ private:
   int qrListLength; 
   queryResp* qrList[50]; //list of queries and responses, 50 max 
 
-  static EspSlackBot* ptrBot; //static ptr to EspSlackBot class for the webSocketEvent handler
+  static ArduinoSlackBot* ptrBot; //static ptr to EspSlackBot class for the webSocketEvent handler
   WebSocketsClient webSocket; //websocket
 
   const char *failMsg; //fail message


### PR DESCRIPTION
Was trying to compile your example, it was failing, stating that there was no type declared for "EspSlackBot" from line 68 in ArduinoSlackBot.h.

It looked like you were renaming the project from EspSlackBot and forgot to change a couple to ArduinoSlackBot, so I did that.
